### PR TITLE
Readded rhel-server-7-ose-beta-rpms

### DIFF
--- a/eap-latest-setup.md
+++ b/eap-latest-setup.md
@@ -219,7 +219,8 @@ can:
         subscription-manager repos --disable="*"
         subscription-manager repos \
         --enable="rhel-7-server-rpms" \
-        --enable="rhel-7-server-extras-rpms"
+        --enable="rhel-7-server-extras-rpms" \
+        --enable="rhel-server-7-ose-beta-rpms"
 
     **Note:** You will have had to register/attach your system first.
 

--- a/eap-latest-setup.md
+++ b/eap-latest-setup.md
@@ -320,7 +320,7 @@ On all of your systems, grab the following docker images:
 
     docker pull registry.access.redhat.com/openshift3/ose-haproxy-router
     docker pull registry.access.redhat.com/openshift3/ose-deployer
-    docker pull registry.access.redhat.com/openshift3/ose-pod:
+    docker pull registry.access.redhat.com/openshift3/ose-pod
     docker pull registry.access.redhat.com/openshift3/ose-docker-registry
 
 It may be advisable to pull the following Docker images as well, since they are

--- a/eap-latest/ansible/hosts
+++ b/eap-latest/ansible/hosts
@@ -27,7 +27,7 @@ deployment_type=enterprise
 #openshift_additional_repos=[{'id': 'openshift-origin-copr', 'name': 'OpenShift Origin COPR', 'baseurl': 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/epel-7-$basearch/', 'enabled': 1, 'gpgcheck': 1, gpgkey: 'https://copr-be.cloud.fedoraproject.org/results/maxamillion/origin-next/pubkey.gpg'}]
 
 # enable htpasswd authentication
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/atomic-passwd'}]
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
 
 # host group for masters
 [masters]


### PR DESCRIPTION
The repository provides `openvswitch` package needed by

    atomic-enterprise-sdn-ovs

Plus some minor fixes.